### PR TITLE
Typo fix Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Library and CLI to work with the ETH keystore file and extract latest validator 
 
 ## Option 1: Running an Executable (Recommended route)
 
-If you want to run a compiled version (easier option then CLI)
+If you want to run a compiled version (easier option than CLI)
 
 1. Go to the releases section: https://github.com/ssvlabs/ssv-keys/releases
 2. Select the latest release for the specific version of the CLI: `vX.Y.Z-v1` - for the first version of the contract, `vX.Y.Z-v2` - for second etc.


### PR DESCRIPTION
**Description:** 

This update addresses a small typo in the README file. The phrase "easier option then CLI" has been corrected to "easier option than CLI". This minor fix ensures that the sentence is grammatically correct and improves readability.

Here is the corrected sentence:

**Before:** "If you want to run a compiled version (easier option then CLI)"  
**After:** "If you want to run a compiled version (easier option than CLI)"

Let me know if any further adjustments are needed!

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
